### PR TITLE
RH-29401: Further decrease number of requests made

### DIFF
--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -19,6 +19,7 @@ class Provider(metaclass=ABCMeta):
         :type base_currency: str
         """
         self._base_currency = base_currency
+        self.has_request_limit = False
         self.request_limit_reached = False
 
         self._cache = Cache(maxsize=1)

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -84,9 +84,9 @@ class Provider(metaclass=ABCMeta):
             if response.status_code == 200:
                 return response
             else:
-                logger.error("%s - status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)
+                logger.error("%s - Status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)
         except requests.exceptions.RequestException as e:
-            logger.error("%s - exception: %s, URL: %s, Params: %s", self, e, url, params)
+            logger.error("%s - Exception: %s, URL: %s, Params: %s", self, e, url, params)
 
     def _to_decimal(self, value, currency=None, *, logger):
         """
@@ -101,7 +101,7 @@ class Provider(metaclass=ABCMeta):
             logger.error("%s - Invalid operation: value %s is not a number (currency %s)", self, value, currency)
 
     def set_request_limit_reached(self, logger):
-        logger.warning("%s - Requests limit exceeded.", self.name)
+        logger.warning("%s - Requests limit exceeded.", self)
         self.request_limit_reached = True
 
     def __str__(self):
@@ -131,7 +131,7 @@ class Provider(metaclass=ABCMeta):
                 if not provider_instance.request_limit_reached:
                     return func(*args, **kwargs)
                 else:
-                    getcallargs(func, *args)["logger"].warning("%s API limit was exceeded. Rate won't be requested.", provider_instance.name)
+                    getcallargs(func, *args)["logger"].warning("%s - API limit was exceeded. Rate won't be requested.", provider_instance.name)
                     return return_value
 
             return wrapper

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -27,7 +27,7 @@ class CurrencyLayer(Provider):
         if access_key:
             self._url = self.BASE_URL % access_key
         else:
-            logger.critical("You need an access token to use CurrencyLayer provider!")
+            logger.critical("%s - You need an access token!", self)
             self._url = self.BASE_URL % ""
 
         self.has_request_limit = True
@@ -44,9 +44,9 @@ class CurrencyLayer(Provider):
         if response:
             currencies = set(re.findall("<td>([A-Z]{3})</td>", response.text))
         if currencies:
-            logger.debug("CurrencyLayer supported currencies: %s", currencies)
+            logger.debug("%s - Supported currencies: %s", self, currencies)
         else:
-            logger.error("CurrencyLayer supported currencies not found.")
+            logger.error("%s - Supported currencies not found.", self)
         return currencies
 
     @Provider.check_request_limit(return_value=None)
@@ -58,11 +58,11 @@ class CurrencyLayer(Provider):
         :rtype: decimal.Decimal | None
         """
         date_str = date_of_exchange.strftime("%Y-%m-%d")
-        logger.debug("Requesting CurrencyLayer for %s (%s)", currency, date_str, extra={"currency": currency, "date": date_str})
+        logger.debug("%s - Requesting for %s (%s)", self, currency, date_str, extra={"currency": currency, "date": date_str})
 
         response = self._get(f"{self._url}&date={date_str}&currencies={currency}", logger=logger)
         if not response:
-            logger.warning("CurrencyLayer error. Status: %s", response.status_code, extra={"currency": currency, "date": date_str})
+            logger.warning("%s - Error. Status: %s", self, response.status_code, extra={"currency": currency, "date": date_str})
             return None
 
         response = response.json()
@@ -73,7 +73,7 @@ class CurrencyLayer(Provider):
             return None
         else:
             logger.warning(
-                "CurrencyLayer unsuccessful request. Error: %s", response.get("error", {}).get("info"), extra={"currency": currency, "date": date_str}
+                "%s - Unsuccessful request. Error: %s", self, response.get("error", {}).get("info"), extra={"currency": currency, "date": date_str}
             )
             return None
 
@@ -88,6 +88,8 @@ class CurrencyLayer(Provider):
         :type logger: gold_digger.utils.ContextLogger
         :rtype: dict[str, decimal.Decimal | None]
         """
+        logger.debug("%s - Requesting for all rates for date %s", self, date_of_exchange)
+
         response = self._get(f"{self._url}&date={date_of_exchange.strftime('%Y-%m-%d')}&currencies={','.join(currencies)}", logger=logger)
         if not response:
             return {}

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -12,7 +12,7 @@ from ._provider import Provider
 
 class CurrencyLayer(Provider):
     """
-    Real-time service with free plan for 1000 requests per month.
+    Real-time service with free plan for 250 requests per month.
     Implicit base currency is USD.
     """
     BASE_URL = "http://www.apilayer.net/api/live?access_key=%s"
@@ -29,6 +29,8 @@ class CurrencyLayer(Provider):
         else:
             logger.critical("You need an access token to use CurrencyLayer provider!")
             self._url = self.BASE_URL % ""
+
+        self.has_request_limit = True
 
     @cachedmethod(cache=attrgetter("_cache"), key=lambda date_of_exchange, _: keys.hashkey(date_of_exchange))
     def get_supported_currencies(self, date_of_exchange, logger):

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -29,6 +29,8 @@ class Fixer(Provider):
             logger.critical("You need an access token to use Fixer provider!")
             self._url = self.BASE_URL % ""
 
+        self.has_request_limit = True
+
     @cachedmethod(cache=attrgetter("_cache"), key=lambda date_of_exchange, _: keys.hashkey(date_of_exchange))
     @Provider.check_request_limit(return_value=set())
     def get_supported_currencies(self, date_of_exchange, logger):

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -26,7 +26,7 @@ class Fixer(Provider):
         if access_key:
             self._url = self.BASE_URL % access_key
         else:
-            logger.critical("You need an access token to use Fixer provider!")
+            logger.critical("%s - You need an access token!", self)
             self._url = self.BASE_URL % ""
 
         self.has_request_limit = True
@@ -48,12 +48,12 @@ class Fixer(Provider):
             elif response["error"]["code"] == 104:
                 self.set_request_limit_reached(logger)
             else:
-                logger.error("Fixer supported currencies not found. Error: %s. Date: %s", response, date_of_exchange.isoformat())
+                logger.error("%s - Supported currencies not found. Error: %s. Date: %s", self, response, date_of_exchange.isoformat())
         else:
-            logger.error("Fixer unexpected response. Response: %s", response)
+            logger.error("%s - Unexpected response. Response: %s", self, response)
 
         if currencies:
-            logger.debug("Fixer supported currencies: %s", currencies)
+            logger.debug("%s - Supported currencies: %s", self, currencies)
 
         return currencies
 
@@ -75,7 +75,8 @@ class Fixer(Provider):
         :type logger: gold_digger.utils.ContextLogger
         :rtype: dict[str, decimal.Decimal]
         """
-        logger.debug("Fixer.io - get all for date %s", date_of_exchange)
+        logger.debug("%s - Requesting for all rates for date %s", self, date_of_exchange)
+
         date_of_exchange_string = date_of_exchange.strftime("%Y-%m-%d")
         day_rates_in_eur = {}
 
@@ -88,7 +89,7 @@ class Fixer(Provider):
                 if not response.get("success"):
                     if response["error"]["code"] == 104:
                         self.set_request_limit_reached(logger)
-                    logger.error("Fixer.io - Unsuccessful response. Response: %s", response)
+                    logger.error("%s - Unsuccessful response. Response: %s", self, response)
                     return {}
 
                 rates = response.get("rates", {})
@@ -99,7 +100,7 @@ class Fixer(Provider):
                         if decimal_value is not None:
                             day_rates_in_eur[currency] = decimal_value
             except Exception:
-                logger.exception("Fixer.io - Exception while parsing of the HTTP response.")
+                logger.exception("%s - Exception while parsing of the HTTP response.", self)
                 return {}
 
         day_rates = {}
@@ -150,7 +151,7 @@ class Fixer(Provider):
         :type logger: gold_digger.utils.ContextLogger
         :rtype: decimal.Decimal | None
         """
-        logger.debug("Requesting Fixer for %s (%s)", currency, date_of_exchange, extra={"currency": currency, "date": date_of_exchange})
+        logger.debug("%s - Requesting for %s (%s)", self, currency, date_of_exchange, extra={"currency": currency, "date": date_of_exchange})
 
         url = self._url.format(path=date_of_exchange)
         response = self._get(url, params={"symbols": "%s,%s" % (self.base_currency, currency)}, logger=logger)
@@ -161,7 +162,7 @@ class Fixer(Provider):
                 if not response.get("success"):
                     if response["error"]["code"] == 104:
                         self.set_request_limit_reached(logger)
-                    logger.error("Fixer.io - Unsuccessful response. Response: %s", response)
+                    logger.error("%s - Unsuccessful response. Response: %s", self, response)
                     return None
 
                 rates = response.get("rates", {})
@@ -173,4 +174,4 @@ class Fixer(Provider):
                      )
 
             except Exception:
-                logger.exception("Fixer.io - Exception while parsing of the HTTP response.")
+                logger.exception("%s - Exception while parsing of the HTTP response.", self)

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -29,9 +29,9 @@ class GrandTrunk(Provider):
         if response:
             currencies = set(response.text.split("\n"))
         if currencies:
-            logger.debug("Grandtrunk supported currencies: %s", currencies)
+            logger.debug("%s - Supported currencies: %s", self, currencies)
         else:
-            logger.error("Grandtrunk supported currencies not found.")
+            logger.error("%s - Supported currencies not found.", self)
         return currencies
 
     def get_by_date(self, date_of_exchange, currency, logger):
@@ -42,7 +42,7 @@ class GrandTrunk(Provider):
         :rtype: decimal.Decimal | None
         """
         date_str = date_of_exchange.strftime("%Y-%m-%d")
-        logger.debug("Requesting GrandTrunk for %s (%s)", currency, date_str, extra={"currency": currency, "date": date_str})
+        logger.debug("%s - Requesting for %s (%s)", self, currency, date_str, extra={"currency": currency, "date": date_str})
 
         response = self._get(f"{self.BASE_URL}/getrate/{date_str}/{self.base_currency}/{currency}", logger=logger)
         if response:
@@ -55,6 +55,8 @@ class GrandTrunk(Provider):
         :type logger: gold_digger.utils.ContextLogger
         :rtype: dict[str, decimal.Decimal | None]
         """
+        logger.debug("%s - Requesting for all rates for date %s", self, date_of_exchange)
+
         day_rates = {}
         supported_currencies = self.get_supported_currencies(date_of_exchange, logger)
         for currency in currencies:

--- a/gold_digger/data_providers/yahoo.py
+++ b/gold_digger/data_providers/yahoo.py
@@ -33,10 +33,10 @@ class Yahoo(Provider):
         :type logger: gold_digger.utils.ContextLogger
         :rtype: decimal.Decimal | None
         """
-        date_str = date_of_exchange.strftime("%Y-%m-%d")
-        logger.debug("Requesting Yahoo for %s (%s)", currency, date_str, extra={"currency": currency, "date": date_str})
-
         if date_of_exchange == date.today():
+            date_str = date_of_exchange.strftime("%Y-%m-%d")
+            logger.debug("%s - Requesting for %s (%s)", self, currency, date_str, extra={"currency": currency, "date": date_str})
+
             return self._get_latest(currency, logger)
 
     def get_all_by_date(self, date_of_exchange, currencies, logger):
@@ -47,6 +47,9 @@ class Yahoo(Provider):
         :rtype: {str: decimal.Decimal | None}
         """
         if date_of_exchange == date.today():
+            date_str = date_of_exchange.strftime("%Y-%m-%d")
+            logger.debug("%s - Requesting rates for all currencies (%s)", self, date_str, extra={"date": date_str})
+
             rates = self._get_all_latest(logger)
             return {currency: rate for currency, rate in rates.items() if currency in currencies}
 
@@ -91,7 +94,7 @@ class Yahoo(Provider):
                         rates[currency] = rate
 
                 except (KeyError, IndexError):
-                    logger.warning("Cannot get rate for {}.".format(currency))
+                    logger.warning("%s - Cannot get rate for %s.", self, currency)
 
         return rates
 

--- a/gold_digger/managers/exchange_rate_manager.py
+++ b/gold_digger/managers/exchange_rate_manager.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from collections import defaultdict, Counter
 from datetime import date, timedelta
 from decimal import Decimal
 from itertools import combinations
-from collections import defaultdict, Counter
 
 from ..database.db_model import ExchangeRate
 
@@ -84,6 +84,12 @@ class ExchangeRateManager:
                     continue
                 else:
                     logger.info("Yesterday's rates for provider %s not found. Requesting API.", data_provider.name)
+            else:
+                if data_provider.has_request_limit:
+                    #  For providers with request limit we don't want to request rates from API for historical data, because it can easily generate hundreds
+                    #  of requests at once and the limit is then soon exceeded.
+                    logger.info("Rates for provider %s aren't in database and provider has disabled requests for historical data.", data_provider.name)
+                    continue
             try:
                 if currency not in data_provider.get_supported_currencies(today, logger):
                     continue

--- a/gold_digger/managers/exchange_rate_manager.py
+++ b/gold_digger/managers/exchange_rate_manager.py
@@ -84,12 +84,12 @@ class ExchangeRateManager:
                     continue
                 else:
                     logger.info("Yesterday's rates for provider %s not found. Requesting API.", data_provider.name)
-            else:
-                if data_provider.has_request_limit:
-                    #  For providers with request limit we don't want to request rates from API for historical data, because it can easily generate hundreds
-                    #  of requests at once and the limit is then soon exceeded.
-                    logger.info("Rates for provider %s aren't in database and provider has disabled requests for historical data.", data_provider.name)
-                    continue
+            elif data_provider.has_request_limit:
+                #  For providers with request limit we don't want to request rates from API for historical data, because it can easily generate hundreds
+                #  of requests at once and the limit is then soon exceeded.
+                logger.info("Rates for provider %s aren't in database and provider has disabled requests for historical data.", data_provider.name)
+                continue
+
             try:
                 if currency not in data_provider.get_supported_currencies(today, logger):
                     continue

--- a/tests/test_exchange_rate_manager.py
+++ b/tests/test_exchange_rate_manager.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from gold_digger.data_providers import CurrencyLayer, GrandTrunk, Fixer
+from gold_digger.data_providers import CurrencyLayer, Fixer, GrandTrunk
 from gold_digger.database.dao_exchange_rate import DaoExchangeRate
 from gold_digger.database.dao_provider import DaoProvider
 from gold_digger.database.db_model import ExchangeRate, Provider


### PR DESCRIPTION
https://roihunter.atlassian.net/browse/RH-29401

Few providers have a limit on requests made per month. From those providers we shouldn't request historical rates if we don't have them in database.
In logs I found several cases when requests day by day for the whole year (or even longer) were made and for most of the days we didn't have the rates. It made almost 500 requests in 5 minutes which is half of the limit for Fixer.io and 2x the limit for CurrencyLayer.
If the requests for our API come day by day we cannot distinguish if it is single day or 500 of them. For most of the days we should have data in db and if not, there are other providers we use which don't have these limits and the request can be made.