### PR TITLE
Dev to Master

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,6 @@ requests = "~=2.21.0"
 SQLAlchemy = "~=1.3.3"
 
 [dev-packages]
-pytest = "~=4.1.1"
+pytest = "~=5.0.0"
 pytest-cov = "~=2.6.1"
 SQLAlchemy-Utils = "~=0.34.0"

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ SQLAlchemy = "~=1.3.3"
 [dev-packages]
 pytest = "~=4.1.1"
 pytest-cov = "~=2.6.1"
-SQLAlchemy-Utils = "~=0.33.11"
+SQLAlchemy-Utils = "~=0.34.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "44532002e5b7c8970b40707da810cebcd0655352bd584a65f9bc839bb164ea2c"
+            "sha256": "912c3ef154a507faf7f02d15673c883063ea6af0f61b93853752d8d36e0d1a16"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -24,11 +24,11 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:219b7dc6024195b6f2bc3d3f884d1fef458745cd323b04165378622dcc823852",
-                "sha256:9efcc9fab3b49ab833475702b55edd5ae07af1af7a4c627678980b45e459c460"
+                "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae",
+                "sha256:8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a"
             ],
             "index": "pypi",
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "certifi": {
             "hashes": [
@@ -163,10 +163,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:91c54ca8345008fceaec987e10924bf07dcab36c442925357e5a467b36a38319"
+                "sha256:c30925d60af95443458ebd7525daf791f55762b106049ae71e18f8dd58084c2f"
             ],
             "index": "pypi",
-            "version": "==1.3.3"
+            "version": "==1.3.5"
         },
         "urllib3": {
             "hashes": [
@@ -241,6 +241,13 @@
             ],
             "version": "==7.1.0"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
@@ -255,13 +262,20 @@
             ],
             "version": "==1.8.0"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
+        },
         "pytest": {
             "hashes": [
-                "sha256:41568ea7ecb4a68d7f63837cf65b92ce8d0105e43196ff2b26622995bb3dc4b2",
-                "sha256:c3c573a29d7c9547fb90217ece8a8843aa0c1328a797e200290dc3d0b4b823be"
+                "sha256:2878de8ae1c79a62c012da6186b88ff0562ea96ce29c4208d2a9b11d9f607df1",
+                "sha256:95b700cf21ed5b7e91bce7a6b5a573b2e3ef7b3643d00f681d8f9c4672f9fbdf"
             ],
             "index": "pypi",
-            "version": "==4.1.1"
+            "version": "==5.0.0"
         },
         "pytest-cov": {
             "hashes": [
@@ -280,10 +294,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:91c54ca8345008fceaec987e10924bf07dcab36c442925357e5a467b36a38319"
+                "sha256:c30925d60af95443458ebd7525daf791f55762b106049ae71e18f8dd58084c2f"
             ],
             "index": "pypi",
-            "version": "==1.3.3"
+            "version": "==1.3.5"
         },
         "sqlalchemy-utils": {
             "hashes": [
@@ -291,6 +305,13 @@
             ],
             "index": "pypi",
             "version": "==0.34.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
         },
         "zipp": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "69ac1269ee58d4bf3d7daed4931f04b191448c10fecd5a8fd1e39399d3849d84"
+            "sha256": "44532002e5b7c8970b40707da810cebcd0655352bd584a65f9bc839bb164ea2c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -32,10 +32,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -170,10 +170,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
-            "version": "==1.24.2"
+            "version": "==1.24.3"
         }
     },
     "develop": {
@@ -190,14 +190,6 @@
                 "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
             "version": "==19.1.0"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
-                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.1"
         },
         "coverage": {
             "hashes": [
@@ -235,19 +227,26 @@
             ],
             "version": "==4.5.3"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+            ],
+            "version": "==0.18"
+        },
         "more-itertools": {
             "hashes": [
-                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
-                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+                "sha256:3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d",
+                "sha256:8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"
             ],
-            "version": "==7.0.0"
+            "version": "==7.1.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
-                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.9.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
@@ -288,10 +287,17 @@
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:3f1cb542cf0549a0de508d4919f3ad693a36230bf4cd13fdd6253549fec71182"
+                "sha256:0ebd4d176a5786233db9f2e92040476fcff8b1b426fdbbb7ee4f478280ee9166"
             ],
             "index": "pypi",
-            "version": "==0.33.11"
+            "version": "==0.34.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
         }
     }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [tool:pytest]
 addopts = --quiet --tb=short --color=yes --cov=gold_digger --cov-report=term-missing --no-cov-on-fail
+markers =
+    slow: Run slow tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,28 @@ import logging
 import pytest
 
 
+rerun_started = False
+
+
 def pytest_addoption(parser):
     parser.addoption("--database-tests", action="store_true", help="Run database tests on real temporary database")
     parser.addoption("--db-connection", action="store", help="Database connection string")
+
+
+def pytest_deselected():
+    """
+    Called when --run-failed was issued
+    """
+    global rerun_started
+    rerun_started = True
+
+
+def pytest_collection_modifyitems(config, items):
+    slow_marker = pytest.mark.skipif(not config.getoption("--database-tests") and not rerun_started, reason="need --database-tests option to run")
+
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(slow_marker)
 
 
 @pytest.fixture(scope="module")

--- a/tests/database/__init__.py
+++ b/tests/database/__init__.py
@@ -1,6 +1,1 @@
 # -*- coding: utf-8 -*-
-
-import pytest
-
-database_test = pytest.mark.skipif(not pytest.config.getoption("--database-tests"), reason="need --database-tests option to run")
-

--- a/tests/database/test_dao.py
+++ b/tests/database/test_dao.py
@@ -8,8 +8,6 @@ import pytest
 from gold_digger.database.dao_exchange_rate import DaoExchangeRate
 from gold_digger.database.dao_provider import DaoProvider
 
-from . import database_test
-
 
 @pytest.fixture
 def dao_exchange_rate(db_session):
@@ -21,7 +19,7 @@ def dao_provider(db_session):
     return DaoProvider(db_session)
 
 
-@database_test
+@pytest.mark.slow
 def test_insert_new_rate(dao_exchange_rate, dao_provider):
     assert dao_exchange_rate.get_rates_by_date_currency(date.today(), "USD") == []
 
@@ -35,7 +33,7 @@ def test_insert_new_rate(dao_exchange_rate, dao_provider):
     assert len(dao_exchange_rate.get_rates_by_date_currency(date.today(), "USD")) == 1
 
 
-@database_test
+@pytest.mark.slow
 def test_insert_exchange_rate_to_db(dao_exchange_rate, dao_provider, logger):
     assert dao_exchange_rate.get_rates_by_date_currency(date.today(), "USD") == []
 
@@ -52,7 +50,7 @@ def test_insert_exchange_rate_to_db(dao_exchange_rate, dao_provider, logger):
     assert len(dao_exchange_rate.get_rates_by_date_currency(date.today(), "USD")) == 2
 
 
-@database_test
+@pytest.mark.slow
 def test_get_sum_of_rates_in_period(dao_exchange_rate, dao_provider):
     start_date = date(2016, 1, 1)
     end_date = date(2016, 1, 10)


### PR DESCRIPTION
### Unsorted
- Bump sqlalchemy-utils from 0.33.11 to 0.34.0
- Fixes tests
- Register slow marker