### PR TITLE
RH-34768: Intervals API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ For running the tests simply use:
 
 ## API endpoints
 
+* `/intervals?from=X&to=Y&date=YYYY-MM-DD`
+    * from currency - required
+    * to currency - required
+    * date of exchange - optional; returns last exchange rates if omitted
+    * example: [http://localhost:8080/intervals?from=EUR&to=USD&date=2005-12-22](http://localhost:8080/intervals?from=EUR&to=USD&date=2005-12-22)
+
 * `/rate?from=X&to=Y&date=YYYY-MM-DD`
     * from currency - required
     * to currency - required

--- a/gold_digger/managers/exchange_rate_manager.py
+++ b/gold_digger/managers/exchange_rate_manager.py
@@ -295,4 +295,41 @@ class ExchangeRateManager:
 
             logger.error("Date range 'count' and/or 'sum' are empty")
 
-        logger.error("Range request failed: from %s to %s", from_currency, to_currency)
+        return None
+
+    def get_exchange_rate_in_intervals_by_date(self, date_of_exchange, from_currency, to_currency, logger):
+        """
+        :type date_of_exchange: datetime.date
+        :type from_currency: str
+        :type to_currency: str
+        :type logger: gold_digger.utils.ContextLogger
+        :rtype: list[dict[str, str]]
+        """
+        daily = self.get_exchange_rate_by_date(date_of_exchange, from_currency, to_currency, logger)
+        if daily is None:
+            return []
+
+        start_date, end_date = date_of_exchange - timedelta(days=6), date_of_exchange
+        weekly = self.get_average_exchange_rate_by_dates(start_date, end_date, from_currency, to_currency, logger)
+        if weekly is None:
+            return []
+
+        start_date, end_date = date_of_exchange - timedelta(days=30), date_of_exchange
+        monthly = self.get_average_exchange_rate_by_dates(start_date, end_date, from_currency, to_currency, logger)
+        if monthly is None:
+            return []
+
+        return [
+            {
+                "interval": "daily",
+                "exchange_rate": str(daily),
+            },
+            {
+                "interval": "weekly",
+                "exchange_rate": str(weekly),
+            },
+            {
+                "interval": "monthly",
+                "exchange_rate": str(monthly),
+            },
+        ]


### PR DESCRIPTION
https://roihunter.atlassian.net/browse/RH-34768

I am quite sad to realize that I already did this before when I introduced /rates API to return exchange rates for each date for the purpose of usage in Fishy which never happened. 😅 I suppose we could remove it. What do you think? @martinvy 

@roihunter/pythonistas 🙏 👍 🐍 