### PR TITLE
RH-36296: Replace RatesApi provider with Frankfurter provider

### DIFF
--- a/gold_digger/data_providers/__init__.py
+++ b/gold_digger/data_providers/__init__.py
@@ -1,6 +1,6 @@
 from ._provider import Provider
 from .currency_layer import CurrencyLayer
 from .fixer import Fixer
+from .frankfurter import Frankfurter
 from .grandtrunk import GrandTrunk
-from .rates_api import RatesAPI
 from .yahoo import Yahoo

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -16,12 +16,13 @@ class CurrencyLayer(Provider):
     BASE_URL = "http://www.apilayer.net/api/live?access_key=%s"
     name = "currency_layer"
 
-    def __init__(self, access_key, logger, *args, **kwargs):
+    def __init__(self, base_currency, access_key, logger):
         """
+        :type base_currency: str
         :type access_key: str
         :type logger: gold_digger.utils.ContextLogger
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(base_currency)
         if access_key:
             self._url = self.BASE_URL % access_key
         else:

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -15,12 +15,13 @@ class Fixer(Provider):
     BASE_URL = "http://data.fixer.io/api/{path}?access_key=%s"
     name = "fixer.io"
 
-    def __init__(self, access_key, logger, *args, **kwargs):
+    def __init__(self, base_currency, access_key, logger):
         """
+        :type base_currency: str
         :type access_key: str
         :type logger: gold_digger.utils.ContextLogger
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(base_currency)
         if access_key:
             self._url = self.BASE_URL % access_key
         else:

--- a/gold_digger/data_providers/frankfurter.py
+++ b/gold_digger/data_providers/frankfurter.py
@@ -7,13 +7,15 @@ from cachetools import cachedmethod, keys
 from ._provider import Provider
 
 
-class RatesAPI(Provider):
+class Frankfurter(Provider):
     """
     Free service for current and historical foreign exchange rates built on top of data published by European Central Bank.
     Rates are updated only on working days around 16:00 CET
+
+    https://www.frankfurter.app/docs/
     """
-    BASE_URL = "http://api.ratesapi.io/api/{date}"
-    name = "rates_api"
+    BASE_URL = "https://api.frankfurter.app/{date}"
+    name = "frankfurter"
 
     @cachedmethod(cache=attrgetter("_cache"), key=lambda date_of_exchange, _: keys.hashkey(date_of_exchange))
     def get_supported_currencies(self, date_of_exchange, logger):
@@ -60,7 +62,7 @@ class RatesAPI(Provider):
                     return {}
 
                 rates = response.get("rates", {})
-                if self.base_currency == "EUR":  # Rates API doesn't return EUR in response if it is base currency
+                if self.base_currency == "EUR":  # API doesn't return EUR in response if it is base currency
                     rates["EUR"] = 1
 
                 for currency in currencies:
@@ -84,7 +86,7 @@ class RatesAPI(Provider):
         date_of_exchange_string = date_of_exchange.strftime("%Y-%m-%d")
         logger.debug("%s - Requesting for %s (%s)", self, currency, date_of_exchange_string, extra={"currency": currency, "date": date_of_exchange_string})
 
-        if currency == "EUR" and self.base_currency == "EUR":  # Rates API in this combination returns error
+        if currency == "EUR" and self.base_currency == "EUR":  # API returns error in this combination
             return self._to_decimal(1, "EUR", logger=logger)
 
         url = self.BASE_URL.format(date=date_of_exchange_string)

--- a/gold_digger/data_providers/frankfurter.py
+++ b/gold_digger/data_providers/frankfurter.py
@@ -62,8 +62,7 @@ class Frankfurter(Provider):
                     return {}
 
                 rates = response.get("rates", {})
-                if self.base_currency == "EUR":  # API doesn't return EUR in response if it is base currency
-                    rates["EUR"] = 1
+                rates[self.base_currency] = 1
 
                 for currency in currencies:
                     if currency in rates:
@@ -86,8 +85,8 @@ class Frankfurter(Provider):
         date_of_exchange_string = date_of_exchange.strftime("%Y-%m-%d")
         logger.debug("%s - Requesting for %s (%s)", self, currency, date_of_exchange_string, extra={"currency": currency, "date": date_of_exchange_string})
 
-        if currency == "EUR" and self.base_currency == "EUR":  # API returns error in this combination
-            return self._to_decimal(1, "EUR", logger=logger)
+        if currency == self.base_currency:
+            return self._to_decimal(1, currency, logger=logger)
 
         url = self.BASE_URL.format(date=date_of_exchange_string)
         response = self._get(url, params={"symbols": currency, "base": self.base_currency}, logger=logger)

--- a/gold_digger/data_providers/yahoo.py
+++ b/gold_digger/data_providers/yahoo.py
@@ -11,6 +11,10 @@ class Yahoo(Provider):
     name = "yahoo"
 
     def __init__(self, base_currency, supported_currencies):
+        """
+        :type base_currency: str
+        :type supported_currencies: set[str]
+        """
         super().__init__(base_currency)
         self._downloaded_rates = {}
         self._supported_currencies = supported_currencies - {

--- a/gold_digger/di.py
+++ b/gold_digger/di.py
@@ -72,9 +72,9 @@ class DiContainer:
     def data_providers(self):
         providers = (
             GrandTrunk(self.base_currency),
-            CurrencyLayer(settings.SECRETS_CURRENCY_LAYER_ACCESS_KEY, self.logger(), self.base_currency),
+            CurrencyLayer(self.base_currency, settings.SECRETS_CURRENCY_LAYER_ACCESS_KEY, self.logger()),
             Yahoo(self.base_currency, settings.SUPPORTED_CURRENCIES),
-            Fixer(settings.SECRETS_FIXER_ACCESS_KEY, self.logger(), self.base_currency),
+            Fixer(self.base_currency, settings.SECRETS_FIXER_ACCESS_KEY, self.logger()),
             RatesAPI(self.base_currency),
         )
         return {provider.name: provider for provider in providers}

--- a/gold_digger/di.py
+++ b/gold_digger/di.py
@@ -75,7 +75,7 @@ class DiContainer:
             CurrencyLayer(self.base_currency, settings.SECRETS_CURRENCY_LAYER_ACCESS_KEY, self.logger()),
             Yahoo(self.base_currency, settings.SUPPORTED_CURRENCIES),
             Fixer(self.base_currency, settings.SECRETS_FIXER_ACCESS_KEY, self.logger()),
-            RatesAPI(self.base_currency),
+            Frankfurter(self.base_currency),
         )
         return {provider.name: provider for provider in providers}
 

--- a/tests/data_providers/conftest.py
+++ b/tests/data_providers/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gold_digger.data_providers import CurrencyLayer, Fixer, RatesAPI, Yahoo
+from gold_digger.data_providers import CurrencyLayer, Fixer, Frankfurter, Yahoo
 
 
 @pytest.fixture
@@ -14,8 +14,8 @@ def fixer(base_currency, logger):
 
 
 @pytest.fixture
-def rates_api(base_currency):
-    return RatesAPI(base_currency)
+def frankfurter(base_currency):
+    return Frankfurter(base_currency)
 
 
 @pytest.fixture

--- a/tests/data_providers/conftest.py
+++ b/tests/data_providers/conftest.py
@@ -10,7 +10,7 @@ def yahoo(base_currency, currencies):
 
 @pytest.fixture
 def fixer(base_currency, logger):
-    return Fixer("simple_access_key", logger, base_currency)
+    return Fixer(base_currency, "simple_access_key", logger)
 
 
 @pytest.fixture
@@ -20,4 +20,4 @@ def rates_api(base_currency):
 
 @pytest.fixture
 def currency_layer(base_currency, logger):
-    return CurrencyLayer("simple_access_key", logger, base_currency)
+    return CurrencyLayer(base_currency, "simple_access_key", logger)

--- a/tests/data_providers/test_frankfurter.py
+++ b/tests/data_providers/test_frankfurter.py
@@ -7,13 +7,13 @@ from requests import Response
 API_RESPONSE_USD = b"""
 {
   "base": "USD",
+  "date": "2019-04-15",
   "rates": {
     "BGN": 1.7288075665,
     "NZD": 1.4787412711,
     "ILS": 3.5618315213,
     "RUB": 64.2633253779,
     "CAD": 1.3312118801,
-    "USD": 1,
     "PHP": 51.6892071069,
     "CHF": 1.0028286043,
     "AUD": 1.3931759922,
@@ -41,49 +41,7 @@ API_RESPONSE_USD = b"""
     "CNY": 6.7061787324,
     "SEK": 9.2467073279,
     "EUR": 0.8839388314
-  },
-  "date": "2019-04-15"
-}
-"""
-
-API_RESPONSE_EUR = b"""
-{
-  "base": "EUR",
-  "rates": {
-    "BGN": 1.9558,
-    "NZD": 1.6729,
-    "ILS": 4.0295,
-    "RUB": 72.7011,
-    "CAD": 1.506,
-    "USD": 1.1313,
-    "PHP": 58.476,
-    "CHF": 1.1345,
-    "ZAR": 15.8192,
-    "AUD": 1.5761,
-    "JPY": 126.66,
-    "TRY": 6.5637,
-    "HKD": 8.8685,
-    "MYR": 4.6573,
-    "THB": 35.936,
-    "HRK": 7.436,
-    "NOK": 9.6018,
-    "IDR": 15906.08,
-    "DKK": 7.4639,
-    "CZK": 25.625,
-    "HUF": 320.25,
-    "GBP": 0.86305,
-    "MXN": 21.2497,
-    "KRW": 1281.37,
-    "ISK": 135.6,
-    "SGD": 1.5299,
-    "BRL": 4.3985,
-    "PLN": 4.2742,
-    "INR": 78.5405,
-    "RON": 4.7618,
-    "CNY": 7.5867,
-    "SEK": 10.4608
-  },
-  "date": "2019-04-15"
+  }
 }
 """
 
@@ -227,35 +185,35 @@ def test_get_all_by_date__currency_unavailable(frankfurter, response, logger):
     assert converted_rates == {}
 
 
-def test_get_by_date__eur_base_eur_target(frankfurter, response, logger):
+def test_get_by_date__base_currency_is_same_as_target_currency(frankfurter, base_currency, logger):
     """
-    Frankfurter API has a bug where it returns error when base currency is EUR and the target currency is also EUR. The data should be manually added to the result.
+    Frankfurter API returns error when base and target currencies are same.
 
     :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
-    :type response: requests.Response
+    :type base_currency: str
     :type logger: logging.Logger
     """
-    frankfurter._base_currency = "EUR"
-
-    converted_rates = frankfurter.get_by_date(date(2019, 4, 16), "EUR", logger)
+    converted_rates = frankfurter.get_by_date(date(2019, 4, 16), base_currency, logger)
     assert converted_rates == Decimal('1')
 
 
-def test_get_all_by_date__eur_base_eur_target(frankfurter, response, logger):
+def test_get_all_by_date__base_currency_is_same_as_target_currency(frankfurter, response, base_currency, logger):
     """
-    Frankfurter API has a bug where it doesn't return EUR rates when it is base currency. The data should be manually added to the result.
+    Frankfurter API returns error when base and target currencies are same.
 
     :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
+    :type base_currency: str
     :type logger: logging.Logger
     """
     response.status_code = 200
-    response._content = API_RESPONSE_EUR
+    response._content = API_RESPONSE_USD
 
-    frankfurter._base_currency = "EUR"
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rates = frankfurter.get_all_by_date(date(2019, 4, 16), {"EUR", "CZK"}, logger)
+    converted_rates = frankfurter.get_all_by_date(date(2019, 4, 16), {base_currency, "CZK"}, logger)
+
     assert converted_rates == {
-        "CZK": Decimal(25.663000000000000255795384873636066913604736328125),
-        "EUR": Decimal(1)
+        base_currency: Decimal(1),
+        "CZK": Decimal(22.6509325555),
     }

--- a/tests/data_providers/test_frankfurter.py
+++ b/tests/data_providers/test_frankfurter.py
@@ -93,168 +93,168 @@ def response():
     return Response()
 
 
-def test_get_by_date__available(rates_api, response, logger):
+def test_get_by_date__available(frankfurter, response, logger):
     """
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 200
     response._content = API_RESPONSE_USD
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rate = rates_api.get_by_date(date(2019, 4, 15), "CZK", logger)
+    converted_rate = frankfurter.get_by_date(date(2019, 4, 15), "CZK", logger)
     assert converted_rate == Decimal(22.6509325555)
 
 
-def test_get_by_date__date_unavailable(rates_api, response, logger):
+def test_get_by_date__date_unavailable(frankfurter, response, logger):
     """
-    Rates API returns rates from last available date when asked for an unavailable one.
+    Frankfurter API returns rates from last available date when asked for an unavailable one.
 
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 200
     response._content = API_RESPONSE_USD
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rate = rates_api.get_by_date(date(2019, 4, 16), "CZK", logger)
+    converted_rate = frankfurter.get_by_date(date(2019, 4, 16), "CZK", logger)
     assert converted_rate == Decimal(22.6509325555)
 
 
-def test_get_by_date__date_too_old(rates_api, response, logger):
+def test_get_by_date__date_too_old(frankfurter, response, logger):
     """
-    Rates API returns error when the specified date is before 1999-01-04.
+    Frankfurter API returns error when the specified date is before 1999-01-04.
 
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 400
     response._content = b'{"error": "Error message"}'
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rates = rates_api.get_by_date(date(1000, 1, 11), "CZK", logger)
+    converted_rates = frankfurter.get_by_date(date(1000, 1, 11), "CZK", logger)
     assert converted_rates is None
 
 
-def test_get_by_date__currency_unavailable(rates_api, response, logger):
+def test_get_by_date__currency_unavailable(frankfurter, response, logger):
     """
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 400
     response._content = b'{"error": "Error message"}'
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rates = rates_api.get_by_date(date(2019, 4, 16), "XXX", logger)
+    converted_rates = frankfurter.get_by_date(date(2019, 4, 16), "XXX", logger)
     assert converted_rates is None
 
 
-def test_get_all_by_date__available(rates_api, response, logger):
+def test_get_all_by_date__available(frankfurter, response, logger):
     """
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 200
     response._content = API_RESPONSE_USD
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rates = rates_api.get_all_by_date(date(2019, 4, 15), {"CZK", "EUR"}, logger)
+    converted_rates = frankfurter.get_all_by_date(date(2019, 4, 15), {"CZK", "EUR"}, logger)
     assert converted_rates == {
         "CZK": Decimal(22.6509325555),
         "EUR": Decimal(0.8839388314)
     }
 
 
-def test_get_all_by_date__date_unavailable(rates_api, response, logger):
+def test_get_all_by_date__date_unavailable(frankfurter, response, logger):
     """
-    Rates API returns rates from last available date when asked for an unavailable one.
+    Frankfurter API returns rates from last available date when asked for an unavailable one.
 
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 200
     response._content = API_RESPONSE_USD
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rates = rates_api.get_all_by_date(date(2019, 4, 16), {"CZK", "EUR"}, logger)
+    converted_rates = frankfurter.get_all_by_date(date(2019, 4, 16), {"CZK", "EUR"}, logger)
     assert converted_rates == {
         "CZK": Decimal(22.6509325555),
         "EUR": Decimal(0.8839388314)
     }
 
 
-def test_get_all_by_date__date_too_old(rates_api, response, logger):
+def test_get_all_by_date__date_too_old(frankfurter, response, logger):
     """
-    Rates API returns error when the specified date is before 1999-01-04.
+    Frankfurter API returns error when the specified date is before 1999-01-04.
 
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 400
     response._content = b'{"error": "Error message"}'
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rates = rates_api.get_all_by_date(date(1000, 1, 11), {"CZK"}, logger)
+    converted_rates = frankfurter.get_all_by_date(date(1000, 1, 11), {"CZK"}, logger)
     assert converted_rates == {}
 
 
-def test_get_all_by_date__currency_unavailable(rates_api, response, logger):
+def test_get_all_by_date__currency_unavailable(frankfurter, response, logger):
     """
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 400
     response._content = b'{"error": "Error message"}'
 
-    rates_api._get = lambda url, **kw: response
+    frankfurter._get = lambda url, **kw: response
 
-    converted_rates = rates_api.get_all_by_date(date(2019, 4, 16), {"XXX"}, logger)
+    converted_rates = frankfurter.get_all_by_date(date(2019, 4, 16), {"XXX"}, logger)
     assert converted_rates == {}
 
 
-def test_get_by_date__eur_base_eur_target(rates_api, response, logger):
+def test_get_by_date__eur_base_eur_target(frankfurter, response, logger):
     """
-    Rates API has a bug where it returns error when base currency is EUR and the target currency is also EUR. The data should be manually added to the result.
+    Frankfurter API has a bug where it returns error when base currency is EUR and the target currency is also EUR. The data should be manually added to the result.
 
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
-    rates_api._base_currency = "EUR"
+    frankfurter._base_currency = "EUR"
 
-    converted_rates = rates_api.get_by_date(date(2019, 4, 16), "EUR", logger)
+    converted_rates = frankfurter.get_by_date(date(2019, 4, 16), "EUR", logger)
     assert converted_rates == Decimal('1')
 
 
-def test_get_all_by_date__eur_base_eur_target(rates_api, response, logger):
+def test_get_all_by_date__eur_base_eur_target(frankfurter, response, logger):
     """
-    Rates API has a bug where it doesn't return EUR rates when it is base currency. The data should be manually added to the result.
+    Frankfurter API has a bug where it doesn't return EUR rates when it is base currency. The data should be manually added to the result.
 
-    :type rates_api: gold_digger.data_providers.rates_api.RatesAPI
+    :type frankfurter: gold_digger.data_providers.frankfurter.Frankfurter
     :type response: requests.Response
     :type logger: logging.Logger
     """
     response.status_code = 200
     response._content = API_RESPONSE_EUR
 
-    rates_api._base_currency = "EUR"
+    frankfurter._base_currency = "EUR"
 
-    converted_rates = rates_api.get_all_by_date(date(2019, 4, 16), {"EUR", "CZK"}, logger)
+    converted_rates = frankfurter.get_all_by_date(date(2019, 4, 16), {"EUR", "CZK"}, logger)
     assert converted_rates == {
         "CZK": Decimal(25.663000000000000255795384873636066913604736328125),
         "EUR": Decimal(1)


### PR DESCRIPTION
https://roihunter.atlassian.net/browse/RH-36296

The new provider has exactly the same API as Fixer, it returns even the same exchange rates, so I reused the Fixer class. I wasn't sure whether we even need such duplicate provider, but I added it anyway.

~I created account in https://exchangeratesapi.io/ and put the access key to Vault & Jenkins.~

Update: After some discussion, I simply replaced the RatesApi provider with Frankfurter provider.

@roihunter/pythonistas please review & merge.