### PR TITLE
RH-34891: Use request limit for Grandtrunk

### DIFF
--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -11,6 +11,9 @@ from requests import RequestException, Session
 class Provider(metaclass=ABCMeta):
     DEFAULT_REQUEST_TIMEOUT = 15  # 15 seconds for both connect & read timeouts
 
+    STATUS_CODE_200_OK = 200
+    STATUS_CODE_503_SERVICE_UNAVAILABLE = 503
+
     def __init__(self, base_currency, http_user_agent):
         """
         :type base_currency: str

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -81,7 +81,7 @@ class Provider(metaclass=ABCMeta):
     def _get(self, url, params=None, *, logger):
         """
         :type url: str
-        :type params: dict[str, str]
+        :type params: None | dict[str, str]
         :type logger: gold_digger.utils.ContextLogger
         :rtype: requests.Response | None
         """

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -97,6 +97,8 @@ class Provider(metaclass=ABCMeta):
         except RequestException as e:
             logger.error("%s - Exception: %s, URL: %s, Params: %s", self, e, url, params)
 
+        return None
+
     def _to_decimal(self, value, currency=None, *, logger):
         """
         :type value: str | float

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 from datetime import date
 from decimal import Decimal, InvalidOperation
 from functools import wraps
+from http import HTTPStatus
 from inspect import getcallargs
 
 from cachetools import Cache
@@ -10,9 +11,6 @@ from requests import RequestException, Session
 
 class Provider(metaclass=ABCMeta):
     DEFAULT_REQUEST_TIMEOUT = 15  # 15 seconds for both connect & read timeouts
-
-    STATUS_CODE_200_OK = 200
-    STATUS_CODE_503_SERVICE_UNAVAILABLE = 503
 
     def __init__(self, base_currency, http_user_agent):
         """
@@ -90,7 +88,7 @@ class Provider(metaclass=ABCMeta):
         try:
             self._http_session.cookies.clear()
             response = self._http_session.get(url, params=params, timeout=self.DEFAULT_REQUEST_TIMEOUT)
-            if response.status_code == 200:
+            if response.status_code == HTTPStatus.OK:
                 return response
             else:
                 logger.error("%s - Status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -63,7 +63,7 @@ class CurrencyLayer(Provider):
 
         response = self._get(f"{self._url}&date={date_str}&currencies={currency}", logger=logger)
         if not response:
-            logger.warning("%s - Error. Status: %s", self, response.status_code, extra={"currency": currency, "date": date_str})
+            logger.warning("%s - Unexpected response. Response: %s", self, response, extra={"currency": currency, "date": date_str})
             return None
 
         response = response.json()

--- a/gold_digger/data_providers/frankfurter.py
+++ b/gold_digger/data_providers/frankfurter.py
@@ -132,7 +132,7 @@ class Frankfurter(Provider):
     def _get(self, url, params=None, *, logger):
         """
         :type url: str
-        :type params: dict[str, str]
+        :type params: None | dict[str, str]
         :type logger: gold_digger.utils.ContextLogger
         :rtype: requests.Response | None
         """

--- a/gold_digger/data_providers/frankfurter.py
+++ b/gold_digger/data_providers/frankfurter.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+from http import HTTPStatus
 from operator import attrgetter
 
 from cachetools import cachedmethod, keys
@@ -138,7 +139,7 @@ class Frankfurter(Provider):
         try:
             self._http_session.cookies.clear()
             response = self._http_session.get(url, params=params, timeout=self.DEFAULT_REQUEST_TIMEOUT)
-            if response.status_code != self.STATUS_CODE_200_OK:
+            if response.status_code != HTTPStatus.OK:
                 logger.error("%s - Status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)
             return response
         except RequestException as e:

--- a/gold_digger/data_providers/frankfurter.py
+++ b/gold_digger/data_providers/frankfurter.py
@@ -138,7 +138,7 @@ class Frankfurter(Provider):
         try:
             self._http_session.cookies.clear()
             response = self._http_session.get(url, params=params, timeout=self.DEFAULT_REQUEST_TIMEOUT)
-            if response.status_code != 200:
+            if response.status_code != self.STATUS_CODE_200_OK:
                 logger.error("%s - Status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)
             return response
         except RequestException as e:

--- a/gold_digger/data_providers/frankfurter.py
+++ b/gold_digger/data_providers/frankfurter.py
@@ -143,3 +143,5 @@ class Frankfurter(Provider):
             return response
         except RequestException as e:
             logger.error("%s - Exception: %s, URL: %s, Params: %s", self, e, url, params)
+
+        return None

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -35,15 +35,14 @@ class GrandTrunk(Provider):
         :type logger: gold_digger.utils.ContextLogger
         :rtype: set[str]
         """
-        currencies = set()
         response = self._get(f"{self.BASE_URL}/currencies/{date_of_exchange.strftime('%Y-%m-%d')}", logger=logger)
         if response is None:
-            return currencies
+            return set()
         if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
             self.set_request_limit_reached(logger)
-            return currencies
+            return set()
         if response.status_code != HTTPStatus.OK:
-            return currencies
+            return set()
 
         currencies = set(response.text.split("\n"))
         if currencies:

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import date, datetime
+from http import HTTPStatus
 from operator import attrgetter
 
 from cachetools import cachedmethod, keys
@@ -38,10 +39,10 @@ class GrandTrunk(Provider):
         response = self._get(f"{self.BASE_URL}/currencies/{date_of_exchange.strftime('%Y-%m-%d')}", logger=logger)
         if not response:
             return currencies
-        if response.status_code == self.STATUS_CODE_503_SERVICE_UNAVAILABLE:
+        if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
             self.set_request_limit_reached(logger)
             return currencies
-        if response.status_code != self.STATUS_CODE_200_OK:
+        if response.status_code != HTTPStatus.OK:
             return currencies
 
         currencies = set(response.text.split("\n"))
@@ -66,10 +67,10 @@ class GrandTrunk(Provider):
         response = self._get(f"{self.BASE_URL}/getrate/{date_str}/{self.base_currency}/{currency}", logger=logger)
         if not response:
             return None
-        if response.status_code == self.STATUS_CODE_503_SERVICE_UNAVAILABLE:
+        if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
             self.set_request_limit_reached(logger)
             return None
-        if response.status_code != self.STATUS_CODE_200_OK:
+        if response.status_code != HTTPStatus.OK:
             return None
 
         return self._to_decimal(response.text.strip(), currency, logger=logger)
@@ -93,10 +94,10 @@ class GrandTrunk(Provider):
             response = self._get(f"{self.BASE_URL}/getrate/{date_of_exchange}/{self.base_currency}/{currency}", logger=logger)
             if not response:
                 continue
-            if response.status_code == self.STATUS_CODE_503_SERVICE_UNAVAILABLE:
+            if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
                 self.set_request_limit_reached(logger)
                 return {}
-            if response.status_code != self.STATUS_CODE_200_OK:
+            if response.status_code != HTTPStatus.OK:
                 continue
 
             decimal_value = self._to_decimal(response.text.strip(), currency, logger=logger)
@@ -119,10 +120,10 @@ class GrandTrunk(Provider):
             response = self._get(f"{self.BASE_URL}/getrange/{origin_date_string}/{date.today()}/{self.base_currency}/{currency}", logger=logger)
             if not response:
                 continue
-            if response.status_code == self.STATUS_CODE_503_SERVICE_UNAVAILABLE:
+            if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
                 self.set_request_limit_reached(logger)
                 return {}
-            if response.status_code != self.STATUS_CODE_200_OK:
+            if response.status_code != HTTPStatus.OK:
                 continue
 
             records = response.text.strip().split("\n") if response else []
@@ -151,7 +152,7 @@ class GrandTrunk(Provider):
         try:
             self._http_session.cookies.clear()
             response = self._http_session.get(url, params=params, timeout=self.DEFAULT_REQUEST_TIMEOUT)
-            if response.status_code != self.STATUS_CODE_200_OK:
+            if response.status_code != HTTPStatus.OK:
                 logger.error("%s - Status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)
             return response
         except RequestException as e:

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -156,3 +156,5 @@ class GrandTrunk(Provider):
             return response
         except RequestException as e:
             logger.error("%s - Exception: %s, URL: %s, Params: %s", self, e, url, params)
+
+        return None

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -145,7 +145,7 @@ class GrandTrunk(Provider):
     def _get(self, url, params=None, *, logger):
         """
         :type url: str
-        :type params: dict[str, str]
+        :type params: None | dict[str, str]
         :type logger: gold_digger.utils.ContextLogger
         :rtype: requests.Response | None
         """

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -37,7 +37,7 @@ class GrandTrunk(Provider):
         """
         currencies = set()
         response = self._get(f"{self.BASE_URL}/currencies/{date_of_exchange.strftime('%Y-%m-%d')}", logger=logger)
-        if not response:
+        if response is None:
             return currencies
         if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
             self.set_request_limit_reached(logger)
@@ -65,7 +65,7 @@ class GrandTrunk(Provider):
         logger.debug("%s - Requesting for %s (%s)", self, currency, date_str, extra={"currency": currency, "date": date_str})
 
         response = self._get(f"{self.BASE_URL}/getrate/{date_str}/{self.base_currency}/{currency}", logger=logger)
-        if not response:
+        if response is None:
             return None
         if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
             self.set_request_limit_reached(logger)
@@ -92,7 +92,7 @@ class GrandTrunk(Provider):
                 continue
 
             response = self._get(f"{self.BASE_URL}/getrate/{date_of_exchange}/{self.base_currency}/{currency}", logger=logger)
-            if not response:
+            if response is None:
                 continue
             if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
                 self.set_request_limit_reached(logger)
@@ -118,7 +118,7 @@ class GrandTrunk(Provider):
         origin_date_string = origin_date.strftime("%Y-%m-%d")
         for currency in currencies:
             response = self._get(f"{self.BASE_URL}/getrange/{origin_date_string}/{date.today()}/{self.base_currency}/{currency}", logger=logger)
-            if not response:
+            if response is None:
                 continue
             if response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
                 self.set_request_limit_reached(logger)

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -125,8 +125,7 @@ class GrandTrunk(Provider):
             if response.status_code != HTTPStatus.OK:
                 continue
 
-            records = response.text.strip().split("\n") if response else []
-            for record in records:
+            for record in response.text.strip().split("\n"):
                 record = record.rstrip()
                 if record:
                     try:

--- a/gold_digger/data_providers/yahoo.py
+++ b/gold_digger/data_providers/yahoo.py
@@ -117,21 +117,23 @@ class Yahoo(Provider):
         :type logger: gold_digger.utils.ContextLogger
         :rtype: dict[str, decimal.Decimal | None]
         """
+        if not response:
+            return {}
+
         rates = {}
-        if response:
-            data = response.json()
-            for i in data["spark"]["result"]:
-                currency = ""
-                try:
-                    currency = i["response"][0]["meta"]["currency"]
-                    rate = i["response"][0]["indicators"]["quote"][0]["close"][0]
-                    rate = self._to_decimal(str(rate), currency, logger=logger)
+        data = response.json()
+        for i in data["spark"]["result"]:
+            currency = ""
+            try:
+                currency = i["response"][0]["meta"]["currency"]
+                rate = i["response"][0]["indicators"]["quote"][0]["close"][0]
+                rate = self._to_decimal(str(rate), currency, logger=logger)
 
-                    if currency in self._supported_currencies:
-                        rates[currency] = rate
+                if currency in self._supported_currencies:
+                    rates[currency] = rate
 
-                except (KeyError, IndexError):
-                    logger.warning("%s - Cannot get rate for %s.", self, currency)
+            except (KeyError, IndexError):
+                logger.warning("%s - Cannot get rate for %s.", self, currency)
 
         return rates
 


### PR DESCRIPTION
https://roihunter.atlassian.net/browse/RH-34891

It's a bit messy with each API having a bit different behavior. I considered returning the response from `Provider._get` always, and thus not having to override it for Grandtrunk (and as it is for Frankfurter already), but that would require us to add some additional checks for the status code to all other providers. This way it's probably less code.

@roihunter/pythonistas Please take a look :-)