### PR TITLE
Updating strategy regarding deployment issues with HPA + HPA API version upgrade

### DIFF
--- a/kubernetes/gold-digger-api-deployment.yaml
+++ b/kubernetes/gold-digger-api-deployment.yaml
@@ -7,7 +7,13 @@ metadata:
         tier: backend
         maintainer: python
 spec:
+    replicas: 1
     revisionHistoryLimit: 3
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxUnavailable: 0
+            maxSurge: 1
     selector:
         matchLabels:
             app: gold-digger

--- a/kubernetes/gold-digger-api-hpa.yaml
+++ b/kubernetes/gold-digger-api-hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
     name: gold-digger-hpa


### PR DESCRIPTION
Updated strategy regarding deployment issues caused by HPA. Also upgraded api version of HPA to `v2` before upgrading kubernetes version from v1.23 to v1.26. Current `autoscaling/v2` [will be deprecated](https://roihunter.atlassian.net/jira/software/c/projects/OPS/boards/10?modal=detail&selectedIssue=OPS-144) in new version.