### PR TITLE
Do not use ruff --diff in PR QA check

### DIFF
--- a/jenkins/pipeline/pr-qa-check.groovy
+++ b/jenkins/pipeline/pr-qa-check.groovy
@@ -76,7 +76,7 @@ pipeline {
                             --name=${dockerImageName}-${env.BUILD_ID} \
                             --user=\$(id -u):\$(id -g) \
                             ${dockerImageName} \
-                            ruff --diff --no-cache --quiet .
+                            ruff --no-cache --quiet .
                     """
                 }
             }


### PR DESCRIPTION
Diff option only shows fixable errors and returns 0 even if unfixable errors are present.