### PR TITLE
Update dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
         labels:
             - "dependencies"
             - "docker"
-        open-pull-requests-limit: 10
+        open-pull-requests-limit: 30
         pull-request-branch-name:
             separator: "-"
         rebase-strategy: "auto"
@@ -16,10 +16,10 @@ updates:
     -   package-ecosystem: "pip"
         directory: "/"
         schedule:
-            interval: "daily"
+            interval: "weekly"
         labels:
             - "dependencies"
-        open-pull-requests-limit: 10
+        open-pull-requests-limit: 30
         pull-request-branch-name:
             separator: "-"
         rebase-strategy: "auto"


### PR DESCRIPTION
I find it annoying that I have to wait until I see a specific library bump, because I often bump the same library across multiple repositories. Together with the fact that our PR checks only trigger on demand, I think it is okay to increase the limit.

We also have a library (ruff) that currently updates daily and dependabot creates a new PR everytime, increasing our PR ID counter unnecessarily, so I would like to make it weekly. I trigger the dependabot sync manually anyway.